### PR TITLE
feat: open external links in new tab

### DIFF
--- a/app/routes/projects.tsx
+++ b/app/routes/projects.tsx
@@ -83,12 +83,12 @@ export default function Projects() {
                         </div>
                       </div>
                     ) : (
-                      <a href={project.github} className="flex-1 bg-gray-900 text-white px-6 py-3 rounded-lg text-center font-semibold hover:bg-gray-800 transition-colors">
+                      <a href={project.github} target="_blank" rel="noopener noreferrer" className="flex-1 bg-gray-900 text-white px-6 py-3 rounded-lg text-center font-semibold hover:bg-gray-800 transition-colors">
                         View Code
                       </a>
                     )}
                     {project.live !== '#' && (
-                      <a href={project.live} className="flex-1 bg-primary text-white px-6 py-3 rounded-lg text-center font-semibold hover:bg-primary-dark transition-colors">
+                      <a href={project.live} target="_blank" rel="noopener noreferrer" className="flex-1 bg-primary text-white px-6 py-3 rounded-lg text-center font-semibold hover:bg-primary-dark transition-colors">
                         Live Demo
                       </a>
                     )}
@@ -141,12 +141,12 @@ export default function Projects() {
                         </div>
                       </div>
                     ) : (
-                      <a href={project.github} className="flex-1 bg-gray-900 text-white px-4 py-2 rounded-lg text-center text-sm font-semibold hover:bg-gray-800 transition-colors">
+                      <a href={project.github} target="_blank" rel="noopener noreferrer" className="flex-1 bg-gray-900 text-white px-4 py-2 rounded-lg text-center text-sm font-semibold hover:bg-gray-800 transition-colors">
                         GitHub
                       </a>
                     )}
                     {project.live !== '#' && (
-                      <a href={project.live} className="flex-1 bg-primary text-white px-4 py-2 rounded-lg text-center text-sm font-semibold hover:bg-primary-dark transition-colors">
+                      <a href={project.live} target="_blank" rel="noopener noreferrer" className="flex-1 bg-primary text-white px-4 py-2 rounded-lg text-center text-sm font-semibold hover:bg-primary-dark transition-colors">
                         Demo
                       </a>
                     )}


### PR DESCRIPTION
This change modifies all external links on the projects page to open in a new tab by adding the `target="_blank"` and `rel="noopener noreferrer"` attributes to the `<a>` tags.

This improves user experience by preventing users from navigating away from the portfolio website when they click on a project's "Live Demo" or "View Code" link.